### PR TITLE
Fix compile error

### DIFF
--- a/meta-openvision/recipes-multimedia/gstplayer/gstplayer_0.1.bb
+++ b/meta-openvision/recipes-multimedia/gstplayer/gstplayer_0.1.bb
@@ -26,7 +26,7 @@ do_install() {
 	install -m 0755 ${S}/gst-1.0/gstplayer_gst-1.0 ${D}${bindir}/gstplayer
 }
 
-pkg_postinst_${PN}() {
+pkg_postinst_ontarget_${PN}() {
 	ln -sf gstplayer ${bindir}/gstplayer_gst-1.0
 }
 


### PR DESCRIPTION
Fix compile error  ....

> ERROR: openvision-enigma2-image-1.0-r0 do_rootfs: Postinstall scriptlets of ['gstplayer'] have failed. If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget_${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
Details of the failure are in /home/raed/build_image/BlackHole/openvision-dm920-oe-core/build/tmp/work/dm920-oe-linux-gnueabi/openvision-enigma2-image/1.0-r0/temp/log.do_rootfs.
ERROR: openvision-enigma2-image-1.0-r0 do_rootfs: 
ERROR: openvision-enigma2-image-1.0-r0 do_rootfs: Function failed: do_rootfs
ERROR: Logfile of failure stored in: /home/raed/build_image/BlackHole/openvision-dm920-oe-core/build/tmp/work/dm920-oe-linux-gnueabi/openvision-enigma2-image/1.0-r0/temp/log.do_rootfs.18656
ERROR: Task (/home/raed/build_image/BlackHole/openvision-dm920-oe-core/meta-openvision/recipes-openvision/images/openvision-enigma2-image.bb:do_rootfs) failed with exit code '1'