### PR TITLE
[libpassthrough] Fix compile error

### DIFF
--- a/meta-dream/recipes-bsp/extra/libpassthrough_0.6.bb
+++ b/meta-dream/recipes-bsp/extra/libpassthrough_0.6.bb
@@ -20,7 +20,7 @@ do_license() {
 }
 
 do_install_append () {
-	rm ${WORKDIR}/image/LICENSE-CLOSE
+	rm ${WORKDIR}/LICENSE-CLOSE
 }
 
 addtask do_license before do_populate_lic after do_unpack


### PR DESCRIPTION
Revert this commit https://github.com/Hains/openvision-dm920-oe-core/commit/0422773fdd63fb68c470f35fcef7e0dd961c947d
to solve install error

 | DEBUG: Executing shell function do_install
| 0 blocks
| rm: cannot remove '/home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/libpassthrough/0.6-r0/image/LICENSE-CLOSE': No such file or directory
| WARNING: /home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/libpassthrough/0.6-r0/temp/run.do_install.26801:1 exit 1 from 'rm /home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/libpassthrough/0.6-r0/image/LICENSE-CLOSE'
| ERROR: Execution of '/home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/libpassthrough/0.6-r0/temp/run.do_install.26801' failed with exit code 1:
| 0 blocks
| rm: cannot remove '/home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/libpassthrough/0.6-r0/image/LICENSE-CLOSE': No such file or directory
| WARNING: /home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/libpassthrough/0.6-r0/temp/run.do_install.26801:1 exit 1 from 'rm /home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/libpassthrough/0.6-r0/image/LICENSE-CLOSE'
| 
ERROR: Task (/home/raed/build_image/920-BlackHole/openvision-dm920-oe-core/meta-dream/recipes-bsp/extra/libpassthrough_0.6.bb:do_install) failed with exit code '1'