### PR TITLE
[minidlna] Fix compile error

### DIFF
--- a/meta-openvision/recipes-multimedia/minidlna/minidlna_1.2.1.bbappend
+++ b/meta-openvision/recipes-multimedia/minidlna/minidlna_1.2.1.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://Update-Gettext-version.patch"


### PR DESCRIPTION
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.19 but the autoconf macros are from gettext version 0.20