### PR TITLE
[minidlna] Fix compile error

### DIFF
--- a/meta-openvision/recipes-multimedia/minidlna/minidlna/Update-Gettext-version.patch
+++ b/meta-openvision/recipes-multimedia/minidlna/minidlna/Update-Gettext-version.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index f343d21..a556b33 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -28,7 +28,7 @@ m4_ifdef([AC_USE_SYSTEM_EXTENSIONS], [AC_USE_SYSTEM_EXTENSIONS])
+ 
+ AM_ICONV
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION(0.19)
++AM_GNU_GETTEXT_VERSION(0.20)
+ 
+ # Checks for programs.
+ AC_PROG_AWK


### PR DESCRIPTION
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.19 but the autoconf macros are from gettext version 0.20