### PR TITLE
[weathermsn] Change md5 checksum to the new one

### DIFF
--- a/meta-openvision/recipes-openvision/enigma2-plugins/enigma2-plugin-extensions-weathermsn.bb
+++ b/meta-openvision/recipes-openvision/enigma2-plugins/enigma2-plugin-extensions-weathermsn.bb
@@ -3,7 +3,7 @@ SUMMARY = "Weather MSN"
 MAINTAINER = "Sirius"
 LICENSE = "GPLv3+"
 HOMEPAGE = "www.gisclub.tv"
-LIC_FILES_CHKSUM = "file://python/Plugins/Extensions/WeatherMSN/plugin.py;beginline=3;endline=19;md5=10bdcaaaec8041e55835067db0506e8d"
+LIC_FILES_CHKSUM = "file://python/Plugins/Extensions/WeatherMSN/plugin.py;beginline=3;endline=19;md5=ffc4a5bf0cc661f90242506d3c0fed50"
 
 inherit gitpkgv allarch rm_python_pyc compile_python_pyo no_python_src
 


### PR DESCRIPTION
ERROR: enigma2-plugin-extensions-weathermsn-0.7+gitAUTOINC+a704ae5593-r0 do_populate_lic: QA Issue: enigma2-plugin-extensions-weathermsn: The LIC_FILES_CHKSUM does not match for file://python/Plugins/Extensions/WeatherMSN/plugin.py;beginline=3;endline=19;md5=10bdcaaaec8041e55835067db0506e8d
enigma2-plugin-extensions-weathermsn: The new md5 checksum is ffc4a5bf0cc661f90242506d3c0fed50