### PR TITLE
[util-linux] Add bbappend file to fix compile error ...

### DIFF
--- a/meta-openvision/recipes-core/util-linux/util-linux/util-linux-random.patch
+++ b/meta-openvision/recipes-core/util-linux/util-linux/util-linux-random.patch
@@ -1,0 +1,11 @@
+--- util-linux-2.30/lib/randutils.c	2017-11-08 13:57:35.457762331 +0100
++++ util-linux-2.30/lib/randutils.c	2017-11-08 13:57:56.168194589 +0100
+@@ -26,7 +26,7 @@
+ #endif
+ 
+ #ifdef HAVE_GETRANDOM
+-# include <sys/random.h>
++# include <linux/random.h>
+ #elif defined (__linux__)
+ # if !defined(SYS_getrandom) && defined(__NR_getrandom)
+    /* usable kernel-headers, but old glibc-headers */

--- a/meta-openvision/recipes-core/util-linux/util-linux_2.%.bbappend
+++ b/meta-openvision/recipes-core/util-linux/util-linux_2.%.bbappend
@@ -1,0 +1,27 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_cube = " \
+    file://util-linux-random.patch \
+"
+
+PACKAGES =+ "util-linux-flock"
+FILES_util-linux-flock = "${base_sbindir}/flock.${BPN}"
+
+ALTERNATIVE_util-linux-flock = "flock"
+ALTERNATIVE_LINK_NAME[flock] = "${base_sbindir}/flock"
+
+# Lower the priorities of util-linux-(u)mount, so that if they happen to
+# become installed, they won't replace the working busybox commands.
+ALTERNATIVE_PRIORITY[mount] = "10"
+ALTERNATIVE_PRIORITY[umount] = "10"
+
+SSTATE_DUPWHITELIST += "${STAGING_DIR_NATIVE}/bin/login"
+
+do_install_append () {
+    if [ "${base_sbindir}" != "${sbindir}" ]; then
+        mkdir -p ${D}${base_sbindir}
+        if [ -f "${D}${bindir}/flock" ]; then
+            mv "${D}${bindir}/flock" "${D}${base_sbindir}/flock"
+        fi
+    fi
+}


### PR DESCRIPTION
> e/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/11.1.1/ld: /usr/src/debug/util-linux/2.37-r0/build/../util-linux-2.37/sys-utils/irqtop.c:370: undefined reference to `endwin'
| collect2: error: ld returned 1 exit status
| make[2]: *** [Makefile:7646: irqtop] Error 1
| make[2]: *** Waiting for unfinished jobs....
